### PR TITLE
Better Dynamic Import Handling

### DIFF
--- a/src/codablellm/cli.py
+++ b/src/codablellm/cli.py
@@ -2,35 +2,31 @@
 The codablellm command line interface.
 """
 
-import json
 import logging
-from enum import Enum
 import os
-from pathlib import Path
 import shlex
-from typing import Dict, Final, List, Optional, Tuple, Union
+from enum import Enum
+from pathlib import Path
+from typing import Final, List, Optional, Type
 
 from click import BadParameter
 from rich import print
 from typer import Argument, Exit, Option, Typer
 
 import codablellm
+import codablellm.logging_config
 from codablellm import container
 from codablellm.core import downloader
 from codablellm.core.decompiler import DecompileConfig
-from codablellm.core.extractor import ExtractConfig
+from codablellm.core.extractor import ExtractConfig, Extractor
 from codablellm.core.utils import (
     CODABLELLM_MAX_WORKERS_ENVIRON_KEY,
     CODABLELLM_PARALLEL_TASKS_ENVIRON_KEY,
-    BuiltinSymbols,
     DynamicSymbol,
 )
-from codablellm.dataset import (
-    DecompiledCodeDatasetConfig,
-    SourceCodeDatasetConfig,
-)
-from codablellm.decompilers.ghidra import Ghidra
-import codablellm.logging_config
+from codablellm.dataset import DecompiledCodeDatasetConfig, SourceCodeDatasetConfig
+from codablellm.decompilers import *
+from codablellm.languages import *
 from codablellm.repoman import ManageConfig
 
 logger = logging.getLogger(__name__)
@@ -132,35 +128,46 @@ def try_create_repo_dir(path: Path) -> Path:
 # Argument/option parsers
 
 
-def parse_builtin_or_dynamic_symbol(
-    param_name: str, value: Union[str, DynamicSymbol], builtin_symbols: BuiltinSymbols
-) -> DynamicSymbol:
-    print(value)
-    raise Exit()
-    if not isinstance(value, str):
-        return value
-    args = shlex.split(value)
-    try:
-        file, symbol = args
-    except ValueError as e1:
-        try:
-            (symbol,) = args
-        except ValueError as e2:
-            raise BadParameter(f"requires 1 or 2 arguments.") from e1
-        else:
-            dynamic_symbol = builtin_symbols.get(symbol)
-            if not dynamic_symbol:
-                raise BadParameter(
-                    f"is not a builtin symbol ({'|'.join(builtin_symbols)})."
-                ) from e1
-            return dynamic_symbol
+def parse_builtin_or_dynamic_symbol(value: str) -> DynamicSymbol:
+    # Check for common classes/functions for decompilers/extractors/mappers
+    def verify_language_support(extractor_type: Type[Extractor], extra: str) -> None:
+        if not extractor_type.is_installed():
+            raise BadParameter(
+                f'{extractor_type.language()} language support requires the "{extra}" extra to be installed. '
+                f'Install with "pip install codablellm[{extra}]" or "pip install codablellm[langs]" to '
+                "install support for all languages."
+            )
+
+    value = value.lower()
+    if value == "ghidra":
+        symbol = DynamicSymbol.from_builtin_symbol(Ghidra)
+    elif value == "c":
+        symbol = DynamicSymbol.from_builtin_symbol(CExtractor)
+    elif value == "c++":
+        symbol = DynamicSymbol.from_builtin_symbol(CPPExtractor)
+    elif value == "java":
+        symbol = DynamicSymbol.from_builtin_symbol(JavaExtractor)
+        verify_language_support(JavaExtractor, "java")
+    elif value == "javascript":
+        symbol = DynamicSymbol.from_builtin_symbol(JavaScriptExtractor)
+        verify_language_support(JavaExtractor, "javascript")
+    elif value == "python":
+        symbol = DynamicSymbol.from_builtin_symbol(PythonExtractor)
+        verify_language_support(JavaExtractor, "python")
+    elif value == "rust":
+        symbol = DynamicSymbol.from_builtin_symbol(RustExtractor)
+        verify_language_support(JavaExtractor, "rust")
+    elif value == "typescript":
+        symbol = DynamicSymbol.from_builtin_symbol(TypeScriptExtractor)
+        verify_language_support(JavaExtractor, "typescript")
     else:
-        file = Path(file)
-        if not file.exists():
-            raise BadParameter(f"{file} is does not exist.")
-        elif not file.is_file():
-            raise BadParameter(f"{file} is not a file.")
-        return (Path(file), symbol)
+        try:
+            symbol = DynamicSymbol.from_str(value)
+        except ValueError as e:
+            raise BadParameter(
+                "Class/function must be in the format of 'path/to/file.py::ClassOrFunction'"
+            ) from e
+    return symbol
 
 
 # Arguments
@@ -217,6 +224,14 @@ CLEANUP: Final[Optional[str]] = Option(
     "cleaned up after the dataset is created, using the value of "
     "this option as the build command.",
 )
+CLEAR_EXTRACTORS: Final[bool] = Option(
+    False,
+    "--clear-extractors",
+    help="Unregister all builtin extractors.",
+    callback=codablellm.extractor.unregister_all,
+    parser=parse_builtin_or_dynamic_symbol,
+    metavar="SYMBOL",
+)
 CONTAINERIZE: Final[bool] = Option(
     False,
     "--containerize / --local",
@@ -232,11 +247,10 @@ DECOMPILE: Final[bool] = Option(
     "argument and add decompiled code to the dataset.",
 )
 DECOMPILER: Final[DynamicSymbol] = Option(
-    codablellm.decompiler._decompiler.symbol,
-    dir_okay=False,
-    exists=True,
+    str(codablellm.decompiler.get()),
     help="Decompiler to use.",
-    metavar=f"<FILE CLASS>",
+    parser=parse_builtin_or_dynamic_symbol,
+    metavar="SYMBOL",
 )
 DEBUG: Final[bool] = Option(
     False, "--debug", callback=toggle_debug_logging, hidden=True
@@ -256,13 +270,6 @@ EXCLUSIVE_SUBPATH: Final[Optional[List[Path]]] = Option(
     help="Path relative to the repository "
     "directory to exclusively include in the dataset "
     "generation.",
-)
-EXTRACTORS: Final[Optional[Tuple[ExtractorConfigOperation, Path]]] = Option(
-    None,
-    dir_okay=False,
-    exists=True,
-    metavar="<[prepend|append|set] FILE>",
-    help="Order of extractors to use, including custom ones.",
 )
 EXTRA_PATH: Final[List[Path]] = Option(
     [],
@@ -308,10 +315,9 @@ CLEANUP_ERROR_HANDLING: Final[CommandErrorHandler] = Option(
     "prompting the user for manual intervention.",
 )
 MAPPER: Final[DynamicSymbol] = Option(
-    DEFAULT_DECOMPILED_CODE_DATASET_CONFIG.mapper,
-    dir_okay=False,
-    exists=True,
-    metavar="<FILE FUNCTION>",
+    str(DEFAULT_DECOMPILED_CODE_DATASET_CONFIG.mapper),
+    parser=parse_builtin_or_dynamic_symbol,
+    metavar="SYMBOL",
     help="Mapper to use for mapping decompiled functions to source code functions.",
 )
 MAX_WORKERS: Final[Optional[int]] = Option(
@@ -361,9 +367,8 @@ TRANSFORM: Final[Optional[DynamicSymbol]] = Option(
     DEFAULT_SOURCE_CODE_DATASET_CONFIG.extract_config.transform,
     "--transform",
     "-t",
-    dir_okay=False,
-    exists=True,
-    metavar="<FILE FUNCTION>",
+    parser=parse_builtin_or_dynamic_symbol,
+    metavar="SYMBOL",
     help="Transformation function to use when extracting source code functions.",
 )
 RECURSIVE: Final[bool] = Option(
@@ -371,6 +376,14 @@ RECURSIVE: Final[bool] = Option(
     "--recursive",
     "-r",
     help="Recursively search for binaries in the specified bins directories.",
+)
+REGISTER_EXTRACTOR: Final[Optional[List[DynamicSymbol]]] = Option(
+    [],
+    "--register-extractor",
+    "-R",
+    parser=parse_builtin_or_dynamic_symbol,
+    metavar="SYMBOL",
+    help="Additional extractor to register.",
 )
 RUN_FROM: Final[RunFrom] = Option(
     DEFAULT_MANAGE_CONFIG.run_from,
@@ -404,17 +417,16 @@ def command(
     cleanup_error_handling: CommandErrorHandler = CLEANUP_ERROR_HANDLING,
     containerize: bool = CONTAINERIZE,
     checkpoint: int = CHECKPOINT,
-    debug: bool = DEBUG,
+    _debug: bool = DEBUG,
     decompile: bool = DECOMPILE,
     decompiler: DynamicSymbol = DECOMPILER,
     exclude_subpath: Optional[List[Path]] = EXCLUDE_SUBPATH,
     exclusive_subpath: Optional[List[Path]] = EXCLUSIVE_SUBPATH,
-    extractors: Optional[Tuple[ExtractorConfigOperation, Path]] = EXTRACTORS,
     extra_path: List[Path] = EXTRA_PATH,
     generation_mode: GenerationMode = GENERATION_MODE,
     git: bool = GIT,
-    ghidra: Optional[Path] = GHIDRA,
-    ghidra_script: Path = GHIDRA_SCRIPT,
+    _ghidra: Optional[Path] = GHIDRA,
+    _ghidra_script: Path = GHIDRA_SCRIPT,
     mapper: DynamicSymbol = MAPPER,
     max_workers: Optional[int] = MAX_WORKERS,
     parallel: bool = PARALLEL,
@@ -425,8 +437,8 @@ def command(
     transform: Optional[DynamicSymbol] = TRANSFORM,
     use_checkpoint: Optional[bool] = USE_CHECKPOINT,
     url: str = URL,
-    verbose: bool = VERBOSE,
-    version: bool = VERSION,
+    _verbose: bool = VERBOSE,
+    _version: bool = VERSION,
 ) -> None:
     """
     Creates a code dataset from a local repository.
@@ -436,28 +448,7 @@ def command(
         return
     if decompiler != codablellm.decompiler.get().symbol:
         # Configure decompiler
-        codablellm.decompiler.set(f"(CLI-Set) {decompiler[1]}", decompiler)
-    if extractors:
-        # Configure function extractors
-        operation, config_file = extractors
-        try:
-            # Load JSON file containing extractors
-            configured_extractors: Dict[str, DynamicSymbol] = json.loads(
-                Path.read_text(config_file)
-            )
-        except json.JSONDecodeError as e:
-            raise BadParameter(
-                "Could not decode extractor configuration file.",
-                param_hint="--extractors",
-            ) from e
-        if operation == ExtractorConfigOperation.SET:
-            codablellm.extractor.set_registered(configured_extractors)
-        else:
-            for language, symbol in configured_extractors.items():
-                order = (
-                    "last" if operation == ExtractorConfigOperation.APPEND else "first"
-                )
-                codablellm.extractor.register(language, symbol, order=order)
+        codablellm.decompiler.set(decompiler)
     if url:
         # Download remote repository
         if git:

--- a/src/codablellm/core/decompiler.py
+++ b/src/codablellm/core/decompiler.py
@@ -18,7 +18,6 @@ from typing import (
     List,
     Literal,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
     Type,
@@ -30,7 +29,6 @@ from codablellm.core.function import DecompiledFunction
 from codablellm.core.utils import (
     CODABLELLM_MAX_WORKERS_ENVIRON_KEY,
     ASTEditor,
-    BuiltinSymbols,
     DynamicSymbol,
     PathLike,
     codablellm_flow,
@@ -44,48 +42,24 @@ from codablellm.languages.c import CExtractor
 logger = logging.getLogger(__name__)
 
 
-class RegisteredDecompiler(NamedTuple):
-    name: str
-    symbol: DynamicSymbol
+_decompiler: DynamicSymbol
 
 
-BUILTIN_SYMBOLS: Final[BuiltinSymbols] = {
-    "Ghidra": (Path(__file__).parent.parent / "decompilers" / "ghidra.py", "Ghidra"),
-    "Angr": (
-        Path(__file__).parent.parent / "decompilers" / "angr_decompiler.py",
-        "Angr",
-    ),
-}
-
-_decompiler: RegisteredDecompiler = RegisteredDecompiler(
-    "Ghidra", BUILTIN_SYMBOLS["Ghidra"]
-)
-
-
-def set(name: str, symbol: DynamicSymbol) -> None:
+def set(decompiler: DynamicSymbol) -> None:
     """
     Sets the decompiler used by `codablellm`.
 
     Parameters:
-        name: The display name of the decompiler (e.g., "Ghidra", "Angr").
         symbol: A tuple containing the file path and class name of the decompiler implementation.
     """
 
     global _decompiler
-    file, class_name = symbol
-    old_decompiler = _decompiler
-    _decompiler = RegisteredDecompiler(name, (Path(file), class_name))
-    # Instantiate decompiler to ensure it can be properly imported
-    try:
-        create_decompiler()
-    except:
-        logger.error(f"Could not create {repr(name)} extractor")
-        _decompiler = old_decompiler
-        raise
-    logger.info(f"Using {repr(name)} ({file}::{class_name}) as the decompiler")
+    decompiler_type: Type[Decompiler] = dynamic_import(decompiler)
+    logger.info(f"Using {repr(decompiler_type.name)} as the decompiler")
+    _decompiler = decompiler
 
 
-def get() -> RegisteredDecompiler:
+def get() -> DynamicSymbol:
     """
     Returns the currently registered decompiler.
 
@@ -239,7 +213,10 @@ class Decompiler(ABC):
             return combined
         logger.debug(f"Utilizing pseudo-strip strategy for {repr(path)}")
         return [pseudo_strip(self, function) for function in self.decompile(path)]
-        # strip, decompile again, and return the stripped functions
+
+    @classmethod
+    def name(cls) -> str:
+        return cls.__name__
 
 
 def create_decompiler(*args: Any, **kwargs: Any) -> Decompiler:
@@ -256,7 +233,7 @@ def create_decompiler(*args: Any, **kwargs: Any) -> Decompiler:
     Raises:
         DecompilerNotFound: If the specified decompiler cannot be imported or if the class cannot be found.
     """
-    decompiler_class: Type[Decompiler] = dynamic_import(_decompiler.symbol)
+    decompiler_class: Type[Decompiler] = dynamic_import(_decompiler)
     return decompiler_class(*args, **kwargs)
 
 
@@ -355,7 +332,7 @@ def decompile_bins_task(
     # Create decompiler
     decompiler = create_decompiler(*config.decompiler_args, **config.decompiler_kwargs)
     # Submit decompile tasks
-    logger.info(f"Submitting {get().name} decompile tasks...")
+    logger.info(f"Submitting {decompiler.name()} decompile tasks...")
     futures = [
         decompile_task.submit(decompiler, bin, config.symbol_remover, return_state=True)
         for bin in bins
@@ -384,3 +361,7 @@ def decompile(
     """
     flow = codablellm_flow if as_flow else lambda: lambda x: x.fn
     return flow()(decompile_bins_task)(*paths, config=config)
+
+
+# Set Ghidra as default decompiler
+set(DynamicSymbol.from_deferred_import("codablellm.decompilers.Ghidra"))

--- a/src/codablellm/core/extractor.py
+++ b/src/codablellm/core/extractor.py
@@ -13,15 +13,15 @@ from typing import (
     Callable,
     Dict,
     Final,
+    FrozenSet,
     List,
-    Literal,
     Mapping,
     NamedTuple,
     Optional,
-    OrderedDict,
     Sequence,
     Set,
     Type,
+    Union,
 )
 
 from codablellm.core.function import SourceFunction
@@ -35,65 +35,17 @@ from codablellm.core.utils import (
 )
 
 
-class RegisteredExtractor(NamedTuple):
-    language: str
-    symbol: DynamicSymbol
-
-
-_EXTRACTORS: Final[OrderedDict[str, RegisteredExtractor]] = OrderedDict(
-    {
-        "C": RegisteredExtractor(
-            "C", (Path(__file__).parent.parent / "languages" / "c.py", "CExtractor")
-        ),
-        "Rust": RegisteredExtractor(
-            "Rust",
-            (Path(__file__).parent.parent / "languages" / "rust.py", "RustExtractor"),
-        ),
-        "JavaScript": RegisteredExtractor(
-            "JavaScript",
-            (
-                Path(__file__).parent.parent / "languages" / "javascript.py",
-                "JavaScriptExtractor",
-            ),
-        ),
-        "Python": RegisteredExtractor(
-            "Python",
-            (
-                Path(__file__).parent.parent / "languages" / "python_language.py",
-                "PythonExtractor",
-            ),
-        ),
-        "C++": RegisteredExtractor(
-            "C++",
-            (Path(__file__).parent.parent / "languages" / "cpp.py", "CPPExtractor"),
-        ),
-        "Java": RegisteredExtractor(
-            "Java",
-            (Path(__file__).parent.parent / "languages" / "java.py", "JavaExtractor"),
-        ),
-        "TypeScript": RegisteredExtractor(
-            "TypeScript",
-            (
-                Path(__file__).parent.parent / "languages" / "typescript.py",
-                "TypeScriptExtractor",
-            ),
-        ),
-    }
-)
-
-BUILTIN_EXTRACTORS: Final[Mapping[str, RegisteredExtractor]] = _EXTRACTORS
+_EXTRACTORS: Final[Dict[str, DynamicSymbol]] = {}
 
 logger = logging.getLogger(__name__)
 
 
-def get_registered() -> Sequence[RegisteredExtractor]:
-    return list(_EXTRACTORS.values())
+def get_registered() -> Dict[str, DynamicSymbol]:
+    return dict(_EXTRACTORS)
 
 
 def register(
-    language: str,
-    symbol: DynamicSymbol,
-    order: Optional[Literal["first", "last"]] = None,
+    extractor: DynamicSymbol,
 ) -> None:
     """
     Registers a new source code extractor for a given language.
@@ -103,42 +55,28 @@ def register(
         class_path: The full import path to the extractor class.
         order: Optional order for insertion. If 'first', prepends the extractor; if 'last', appends it.
     """
-    file, class_name = symbol
-    registered_extractor = RegisteredExtractor(language, (Path(file), class_name))
-    if _EXTRACTORS.setdefault(language, registered_extractor) != registered_extractor:
-        raise ValueError(f"{repr(language)} is already a registered extractor")
-    if order:
-        _EXTRACTORS.move_to_end(language, last=order == "last")
-    # Instantiate extractor to ensure it can be properly imported
-    try:
-        create_extractor(language)
-    except:
-        logger.error(f"Could not create {repr(language)} extractor")
-        unregister(language)
-        raise
-    logger.info(f"Registered {repr(language)} extractor at {file}::{class_name}")
+    extractor_type: Type[Extractor] = dynamic_import(extractor)
+    language = extractor_type.language()
+    logger.info(f"Registering a {language} extractor at {extractor}")
+    if _EXTRACTORS.setdefault(language.lower(), extractor) != extractor:
+        raise ValueError(
+            f"An extractor is already registered for the {language} language"
+        )
 
 
-def unregister(language: str) -> None:
-    del _EXTRACTORS[language]
-    logger.info(f"Unregistered {repr(language)} extractor")
+def unregister(symbol_or_language: Union[DynamicSymbol, str]) -> None:
+    if isinstance(symbol_or_language, str):
+        key = symbol_or_language
+    else:
+        (key,) = [k for k, v in _EXTRACTORS.items() if v == symbol_or_language]
+    extractor = _EXTRACTORS[key]
+    del _EXTRACTORS[key]
+    logger.info(f"Unregistered {key} extractor at {extractor}")
 
 
 def unregister_all() -> None:
     _EXTRACTORS.clear()
     logger.info("Unregistered all extractors")
-
-
-def set_registered(extractors: Mapping[str, DynamicSymbol]) -> None:
-    """
-    Replaces all existing source code extractors with a new set.
-
-    Parameters:
-        extractors: A mapping from language names to extractor class paths.
-    """
-    unregister_all()
-    for language, symbol in extractors.items():
-        register(language, symbol)
 
 
 class Extractor(ABC):
@@ -178,8 +116,13 @@ class Extractor(ABC):
         """
         pass
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return True
+
+    @classmethod
+    def language(cls) -> str:
+        return cls.__name__.replace("Extractor", "")
 
 
 def create_extractor(language: str, *args: Any, **kwargs: Any) -> Extractor:
@@ -198,7 +141,7 @@ def create_extractor(language: str, *args: Any, **kwargs: Any) -> Extractor:
         ExtractorNotFound: If no extractor is registered for the specified language.
     """
     if language in _EXTRACTORS:
-        extractor_class: Type[Extractor] = dynamic_import(_EXTRACTORS[language].symbol)
+        extractor_class: Type[Extractor] = dynamic_import(_EXTRACTORS[language])
         return extractor_class(*args, **kwargs)
     raise ValueError(f'"{language}" is not a registered extractor')
 
@@ -360,3 +303,24 @@ def extract(
 ) -> List[SourceFunction]:
     futures = [extract_directory_task.submit(path, config=config) for path in paths]
     return [function for future in futures for function in future.result()]
+
+
+# Register builtin extractors that are installed
+for extractor in [
+    DynamicSymbol.from_deferred_import("codablellm.languages.c.CExtractor"),
+    DynamicSymbol.from_deferred_import("codablellm.languages.cpp.CPPExtractor"),
+    DynamicSymbol.from_deferred_import("codablellm.languages.java.JavaExtractor"),
+    DynamicSymbol.from_deferred_import(
+        "codablellm.languages.javascript.JavaScriptExtractor"
+    ),
+    DynamicSymbol.from_deferred_import(
+        "codablellm.languages.python_language.PythonExtractor"
+    ),
+    DynamicSymbol.from_deferred_import("codablellm.languages.rust.RustExtractor"),
+    DynamicSymbol.from_deferred_import(
+        "codablellm.languages.typescript.TypeScriptExtractor"
+    ),
+]:
+    extractor_type: Type[Extractor] = dynamic_import(extractor)
+    if extractor_type.is_installed():
+        register(extractor)

--- a/src/codablellm/core/mapper.py
+++ b/src/codablellm/core/mapper.py
@@ -1,7 +1,6 @@
-from pathlib import Path
-from typing import Callable, Final, Tuple, Union
+from typing import Callable, Final, Union
 from codablellm.core.function import DecompiledFunction, SourceFunction
-from codablellm.core.utils import BuiltinSymbols, DynamicSymbol
+from codablellm.core.utils import DynamicSymbol
 
 
 def name_mapper(function: DecompiledFunction, uid: Union[SourceFunction, str]) -> bool:
@@ -55,19 +54,7 @@ corresponds to a given source function.
 """
 
 
-def _create_builtin_symbol(mapper: Mapper) -> Tuple[str, DynamicSymbol]:
-    return mapper.__name__, (Path(__file__), mapper.__name__)
-
-
-BUILTIN_MAPPERS: Final[BuiltinSymbols] = dict(
-    [
-        _create_builtin_symbol(default_mapper),
-        _create_builtin_symbol(name_mapper),
-        _create_builtin_symbol(rust_linux_mapper),
-    ]
-)
-
-DEFAULT_MAPPER: Final[DynamicSymbol] = BUILTIN_MAPPERS["default_mapper"]
+DEFAULT_MAPPER: Final[DynamicSymbol] = DynamicSymbol.from_builtin_symbol(default_mapper)
 """
 The default mapping function used to match decompiled functions to source functions.
 """

--- a/src/codablellm/core/utils.py
+++ b/src/codablellm/core/utils.py
@@ -2,6 +2,7 @@
 Core utility functions for codablellm.
 """
 
+from dataclasses import dataclass
 import importlib
 import json
 import logging
@@ -610,14 +611,51 @@ def prepared_dir(
             os.environ.pop(REBASED_DIR_ENVIRON_KEY, None)
 
 
-DynamicSymbol = Tuple[Path, str]
+@dataclass
+class DynamicSymbol:
+    path: Path
+    symbol: str
+
+    def __hash__(self) -> int:
+        return hash((self.path, self.symbol))
+
+    def __str__(self) -> str:
+        return f"{self.path}::{self.symbol}"
+
+    @staticmethod
+    def package_root() -> Path:
+        return Path(__file__).parent.parent.parent
+
+    @classmethod
+    def from_str(cls, import_str: str) -> "DynamicSymbol":
+        try:
+            file, symbol = import_str.split("::", maxsplit=1)
+        except ValueError as e:
+            raise ValueError(
+                'Import string must be in the format of "path/to/file.py::ClassOrFunction"'
+            ) from e
+        return cls(Path(file), symbol)
+
+    @classmethod
+    def from_deferred_import(cls, import_str: str) -> "DynamicSymbol":
+        module, symbol = import_str.rsplit(".", maxsplit=1)
+        path = cls.package_root()
+        for module_segment in module.split("."):
+            path /= module_segment
+        return cls.from_str(f"{path}::{symbol}")
+
+    @classmethod
+    def from_builtin_symbol(cls, symbol: Union[Type[Any], Callable]) -> "DynamicSymbol":
+        return cls.from_deferred_import(f"{symbol.__module__}.{symbol.__name__}")
 
 
 def dynamic_import(dynamic_symbol: DynamicSymbol) -> Any:
-    file, symbol = dynamic_symbol
-    file = Path(file)
+    DynamicSymbol.from_builtin_symbol(dynamic_import)
+    file = Path(dynamic_symbol.path)
+    symbol = dynamic_symbol.symbol
     # Add parent directory to sys.path to allow for dynamic imports of extractors and mappers
-    sys.path.insert(0, str(file.parent))
+    if str(file.parent) not in sys.path:
+        sys.path.insert(0, str(file.parent))
     try:
         module = importlib.import_module(file.stem)
         return getattr(module, symbol)

--- a/src/codablellm/dataset.py
+++ b/src/codablellm/dataset.py
@@ -367,7 +367,7 @@ class DecompiledCodeDatasetConfig:
     """
     Configuration settings for decompiling binaries.
     """
-    mapper: utils.DynamicSymbol = DEFAULT_MAPPER
+    mapper: utils.DynamicSymbol = field(default_factory=lambda: DEFAULT_MAPPER)
     """
     The mapping function used to determine if a decompiled function corresponds to a given source function.
     """

--- a/src/codablellm/languages/__init__.py
+++ b/src/codablellm/languages/__init__.py
@@ -3,5 +3,19 @@ Built-in source code function extraction for a subset of languages.
 """
 
 from codablellm.languages.c import CExtractor
+from codablellm.languages.cpp import CPPExtractor
+from codablellm.languages.java import JavaExtractor
+from codablellm.languages.javascript import JavaScriptExtractor
+from codablellm.languages.python_language import PythonExtractor
+from codablellm.languages.rust import RustExtractor
+from codablellm.languages.typescript import TypeScriptExtractor
 
-__all__ = ["CExtractor"]
+__all__ = [
+    "CExtractor",
+    "CPPExtractor",
+    "JavaExtractor",
+    "JavaScriptExtractor",
+    "PythonExtractor",
+    "RustExtractor",
+    "TypeScriptExtractor",
+]

--- a/src/codablellm/languages/cpp.py
+++ b/src/codablellm/languages/cpp.py
@@ -1,10 +1,9 @@
 from pathlib import Path
-from typing import Final, Optional, Sequence, Set
+from typing import Final, Set
 
 import tree_sitter_cpp as tscpp
 from tree_sitter import Language
 
-from codablellm.core.function import SourceFunction
 from codablellm.core.utils import PathLike
 from codablellm.languages.common import TreeSitterExtractor, rglob_file_extensions
 
@@ -48,3 +47,7 @@ class CPPExtractor(TreeSitterExtractor):
 
     def get_language(self) -> Language:
         return Language(tscpp.language())
+
+    @classmethod
+    def language(cls) -> str:
+        return "C++"

--- a/src/codablellm/languages/java.py
+++ b/src/codablellm/languages/java.py
@@ -1,7 +1,6 @@
 from pathlib import Path
-from typing import Final, Optional, Sequence, Set
+from typing import Final, Set
 
-from codablellm.decompilers.angr_decompiler import is_installed
 
 try:
     import tree_sitter_java as tsj
@@ -10,7 +9,6 @@ except ModuleNotFoundError:
 
 from tree_sitter import Language
 
-from codablellm.core.function import SourceFunction
 from codablellm.core.utils import PathLike, requires_extra
 from codablellm.languages.common import TreeSitterExtractor, rglob_file_extensions
 
@@ -87,5 +85,6 @@ class JavaExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tsj.language())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tsj is not None

--- a/src/codablellm/languages/javascript.py
+++ b/src/codablellm/languages/javascript.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Final, Optional, Sequence, Set
+from typing import Final, Set
 
 try:
     import tree_sitter_javascript as tsjs
@@ -8,7 +8,6 @@ except ModuleNotFoundError:
 
 from tree_sitter import Language
 
-from codablellm.core.function import SourceFunction
 from codablellm.core.utils import PathLike, requires_extra
 from codablellm.languages.common import TreeSitterExtractor, rglob_file_extensions
 
@@ -60,5 +59,6 @@ class JavaScriptExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tsjs.language())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tsjs is not None

--- a/src/codablellm/languages/python_language.py
+++ b/src/codablellm/languages/python_language.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Final, Optional, Sequence, Set
+from typing import Final, Set
 
 try:
     import tree_sitter_python as tsp
@@ -8,7 +8,6 @@ except ModuleNotFoundError:
 
 from tree_sitter import Language
 
-from codablellm.core.function import SourceFunction
 from codablellm.core.utils import PathLike, requires_extra
 from codablellm.languages.common import TreeSitterExtractor, rglob_file_extensions
 
@@ -43,5 +42,6 @@ class PythonExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tsp.language())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tsp is not None

--- a/src/codablellm/languages/rust.py
+++ b/src/codablellm/languages/rust.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Final, Optional, Sequence, Set
+from typing import Final, Set
 
 try:
     import tree_sitter_rust as tsr
@@ -8,7 +8,6 @@ except ModuleNotFoundError:
 
 from tree_sitter import Language
 
-from codablellm.core.function import SourceFunction
 from codablellm.core.utils import PathLike, requires_extra
 from codablellm.languages.common import TreeSitterExtractor, rglob_file_extensions
 
@@ -43,5 +42,6 @@ class RustExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tsr.language())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tsr is not None

--- a/src/codablellm/languages/typescript.py
+++ b/src/codablellm/languages/typescript.py
@@ -69,7 +69,8 @@ class TypeScriptExtendedExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tst.language_tsx())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tst is not None
 
 
@@ -103,5 +104,6 @@ class TypeScriptExtractor(TreeSitterExtractor):
     def get_language(self) -> Language:
         return Language(tst.language_typescript())  # type: ignore
 
-    def is_installed(self) -> bool:
+    @staticmethod
+    def is_installed() -> bool:
         return tst is not None


### PR DESCRIPTION
## Summary

Refactored `--extractors` and `DynamicSymbol`s in general.

## Checklist

- [X] Follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Ready to be reviewed and merged

## What’s Changed

- `DynamicSymbol` is changed from a 2-tuple to a dataclass
- Removed awkward CLI options when using dynamic symbols. Now it is in the format of `path/to/script.py::ClassOrFunction`.
- Removed `--extractors`. Added `--register-extractor`, `--clear-extractors`.
- Refactored global variables for storing mappers, decompilers, and extractors to a much simpler format.

## Notes for Reviewers

<!-- Anything reviewers should know or look out for -->
